### PR TITLE
Blimpy submodule updates + Time Profiling Infrastructure on DOTParallel.py and DOT_utils.py

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "blimpy"]
-	path = blimpy
+	path = /mnt/primary/scratch/igerrard/ASP/blimpy
 	url = https://github.com/UCBerkeleySETI/blimpy.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "blimpy"]
+	path = blimpy
+	url = https://github.com/UCBerkeleySETI/blimpy.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "blimpy"]
-	path = /mnt/primary/scratch/igerrard/ASP/blimpy
-	url = https://github.com/UCBerkeleySETI/blimpy.git
+	path = blimpy
+	url = ./src/blimpy
+	# url = https://github.com/UCBerkeleySETI/blimpy.git

--- a/DOT_utils.py
+++ b/DOT_utils.py
@@ -54,13 +54,14 @@ def get_elapsed_time(start=0):
 # check log file for completeness
 def check_logs(log, bliss=False):
     status="fine"
-    if bliss == True:
-        print("Logging disabled (likely for functionality between bliss and NBeamAnalysis), see also edit to get_dats")
+    if bliss: # prints a million times
+        # print("Logging disabled (likely for functionality between bliss and NBeamAnalysis), see also edit to get_dats")
+        return status
     else:
-        searchfile = open(log,'r').readlines()
-        if os.path.exists(log)==False:
+        if not os.path.exists(log):
             logging.info("Can't find log file...")
             return "incomplete"
+        searchfile = open(log,'r').readlines()
         if searchfile[-1]!='===== END OF LOG\n':
             status="incomplete"
     return status
@@ -76,13 +77,16 @@ def get_dats(root_dir,beam,bliss):
         # if 'test' in dirpath:
         #     print(f'Skipping "test" folder:\n{dirpath}')
         #     continue
+        if bliss: # print only once
+            print("Logging disabled (likely for functionality between bliss and NBeamAnalysis), see also edit to get_dats")
         for f in filenames:
             if f.endswith('.dat') and f.split('beam')[-1].split('.')[0]==beam:
-                log_file = os.path.join(dirpath, f).replace('.dat','.log')
-                if check_logs(log_file, bliss=bliss)=="incomplete": #or not os.path.isfile(log_file): <---- this is the edit to get_dats()
-                    logging.info(f"{log_file} is incomplete. Please check it. Skipping this file...")
-                    errors+=1
-                    continue
+                if not bliss: # currently bliss does not have log files
+                    log_file = os.path.join(dirpath, f).replace('.dat','.log')
+                    if check_logs(log_file, bliss=bliss)=="incomplete": #or not os.path.isfile(log_file): <---- this is the edit to get_dats()
+                        logging.info(f"{log_file} is incomplete. Please check it. Skipping this file...")
+                        errors+=1
+                        continue
                 dat_files.append(os.path.join(dirpath, f))
     return dat_files,errors
 

--- a/DOT_utils.py
+++ b/DOT_utils.py
@@ -188,14 +188,14 @@ def comb_df(df, outdir='./', obs='UNKNOWN', resume_index=None, pickle_off=False,
         if resume_index is not None and r < resume_index:
             continue  # skip rows before the resume index
         # identify the target beam .fil file 
-        print("1) is it this taking a while?")
+        # print("1) is it this taking a while?")
         matching_col = row.filter(like='fil_').apply(lambda x: x == row['dat_name']).idxmax()
-        print("done")
+        # print("done")
         target_fil = row[matching_col]
         # get the filterbank metadata
-        print("2) is it this taking a while?")
+        # print("2) is it this taking a while?")
         fil_meta = bl.Waterfall(target_fil,load_data=False)
-        print("done")
+        # print("done")
         # determine the frequency boundaries in the .fil file
         minimum_frequency = fil_meta.container.f_start
         maximum_frequency = fil_meta.container.f_stop

--- a/DOT_utils.py
+++ b/DOT_utils.py
@@ -10,7 +10,7 @@ import os
 import glob
 import argparse
 import sys
-sys.path.append("../blimpy")
+sys.path.append('/mnt/primary/scratch/igerrard/ASP/blimpy')
 import blimpy as bl
 # import blimpy as bl
 # from blimpy.io import hdf_reader

--- a/DOT_utils.py
+++ b/DOT_utils.py
@@ -199,7 +199,7 @@ def comb_df(df, outdir='./', obs='UNKNOWN', resume_index=None, pickle_off=False,
         ~ .5 seconds and called ~2000 times
         esp the hdf reader
         specifically dataset.py ? and being called almost 3 times per call of waterfall?
-        """"
+        """
         try:
             fil_meta = bl.Waterfall(target_fil,load_data=False)
         except Exception as e:
@@ -209,6 +209,7 @@ def comb_df(df, outdir='./', obs='UNKNOWN', resume_index=None, pickle_off=False,
             continue
         """END - ATTN"""
         # print("done")
+        
         # determine the frequency boundaries in the .fil file
         minimum_frequency = fil_meta.container.f_start
         maximum_frequency = fil_meta.container.f_stop
@@ -228,8 +229,14 @@ def comb_df(df, outdir='./', obs='UNKNOWN', resume_index=None, pickle_off=False,
         f1=round(max(fmid-half_span*1e-6,minimum_frequency),6)
         f2=round(min(fmid+half_span*1e-6,maximum_frequency),6)
         # grab the signal data in the target beam fil file
-        """ATTENTION - this calls wf_data which takes .5s and about 1000 calls but seems like calling waterfall twice? """
-        frange,s0=wf_data(target_fil,f1,f2)
+        """
+        ATTENTION - this calls wf_data which takes .5s and about 1000 calls but seems like calling waterfall twice?
+        """
+        #now set f_start and f_stop of the waterfall and call read_data 
+        # then grab data for frange,s0
+        frange,s0=wf_data(target_fil,f1,f2) # bl.Waterfall(fil,f1,f2).grab_data(f1,f2)
+        
+        
         # calculate the SNR
         SNR0 = mySNR(s0)
         # get a list of all the other fil files for all the other beams

--- a/DOT_utils.py
+++ b/DOT_utils.py
@@ -10,7 +10,7 @@ import os
 import glob
 import argparse
 import sys
-sys.path.append("./blimpy/blimpy")
+sys.path.append("../blimpy")
 import blimpy as bl
 # import blimpy as bl
 # from blimpy.io import hdf_reader

--- a/DOT_utils_copy.py
+++ b/DOT_utils_copy.py
@@ -126,6 +126,15 @@ def wf_data(fil,f1,f2):
     # print("\t**in wf_data calling bl.waterfall**", flush=True)
     return bl.Waterfall(fil,f1,f2).grab_data(f1,f2)
 
+def wf_blob_data(fil,f1,f2):
+    idx_start, idx_stop = self.get_frequency_indices(f1, f2)
+
+    # Define blob dimensions (time, beams, freq range)
+    blob_dim = (self.reader.n_ints_in_file, 1, idx_stop - idx_start)
+
+    # Use `read_blob` to extract the data
+    blob = self.reader.read_blob(blob_dim, n_blob=0)
+
 # def get_wf(fil):
 #     print(f"Loading bl.Waterfall for {fil} - only once for this node")
 #     return bl.Waterfall(fil)
@@ -162,10 +171,11 @@ def mid_90(da,p=5):
 
 # My method for calculating SNR
 def mySNR(power):
-    # get the median of the noise
-    median_noise=noise_median(power)
     # assume the middle 90 percent of the array represent the noise
-    noise_els=mid_90(power)             
+    noise_els=mid_90(power)  
+    # get the median of the noise
+    # median_noise=noise_median(power) # call mid_90 only 1x
+    median_noise=np.median(mid_90)
     # zero out the noise by subtracting off the median
     zeroed_noise=noise_els-median_noise     
     # get the standard deviation of the noise using median instead of mean

--- a/DOT_utils_edit.py
+++ b/DOT_utils_edit.py
@@ -228,7 +228,7 @@ def comb_df(df, outdir='./', obs='UNKNOWN', resume_index=None, pickle_off=False,
     except Exception as e:
         print(f"FAILED : fil_meta = bl.Waterfall(target_fil, load_data=False) for {target_fil}")
         print(e)
-        logging.info(f"Failed to load fil meta with bl.Waterfall for {target_fil} - skipping this row...")
+        logging.info(f"Failed to load fil meta with bl.Waterfall for {target_fil} - skipping this node...")
         return
     
     # determine the frequency boundaries in the .fil file

--- a/DOTnbeam.py
+++ b/DOTnbeam.py
@@ -1,4 +1,4 @@
-w'''
+'''
 This is the serial version of the code. It does the same thing as DOTparallel.py, 
 but processes one dat file at a time and utilizes pickle states for resuming an interrupted process.
 

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -32,7 +32,8 @@ import argparse
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from matplotlib.ticker import ScalarFormatter
-import DOT_utils as DOT
+# import DOT_utils as DOT
+import DOT_utils_copy as DOT
 import logging
 import psutil
 import threading
@@ -121,7 +122,7 @@ def dat_to_dataframe(args):
     dat, datdir, fildir, outdir, obs, sf, count_lock, proc_count, ndats, before, after = args
     start = time.time()
 
-    dd_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel_debug/data_to_dataframe/"+dat+"/"
+    dd_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+PROF_DST+"/data_to_dataframe/"+dat+"/"
     dataframe_profiler = profile_manager.start_profiler("proc", "1_dat_to_dataframe", dd_time_dst, restart=RESTART)
 
     """ATTENTION - 0.0, 132m, 136m, 76m, 64m, 84m, 125m, 190m, 75m, 0.0, 3m, 69m, 38m
@@ -268,7 +269,7 @@ def dat_to_dataframe(args):
 
     # Main program execution
 def main(cmd_args):
-    scan_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel_debug/"
+    scan_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+PROF_DST
     dp_profiler = profile_manager.start_profiler("scan", 0, scan_time_dst, dataset = SCAN, restart=RESTART)
 
     """OKAY - Threading takes 0.0 seconds"""
@@ -509,6 +510,7 @@ def main(cmd_args):
 NIGHT = r"2024-12-13-02:09:48/"
 SCAN = r"fil_60657_39349_70813781_radec5.389,23.168_0001/"
 RESTART = False
+PROF_DST = "Debug/full_waterfall_and_vec/"
 
 if __name__ == "__main__":
     # in this case the arguments are given as command line arguments

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -121,7 +121,7 @@ def dat_to_dataframe(args):
     dat, datdir, fildir, outdir, obs, sf, count_lock, proc_count, ndats, before, after = args
     start = time.time()
 
-    dd_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel2/data_to_dataframe/"+dat+"/"
+    dd_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel_debug/data_to_dataframe/"+dat+"/"
     dataframe_profiler = profile_manager.start_profiler("proc", "1_dat_to_dataframe", dd_time_dst, restart=RESTART)
 
     """ATTENTION - 0.0, 132m, 136m, 76m, 64m, 84m, 125m, 190m, 75m, 0.0, 3m, 69m, 38m
@@ -252,7 +252,7 @@ def dat_to_dataframe(args):
             comb_df_profiler = profile_manager.start_profiler("proc", "6_DOT.comb_df", dd_time_dst, restart=RESTART)
             comb_profiler.add_section(f"\tCombing through the remaining {len(df)} hits.")
             logging.info(f"\tCombing through the remaining {len(df)} hits.")
-            print(np.shape(df))
+            # print(np.shape(df))
             temp_df = DOT.comb_df(df,outdir,obs,pickle_off=True,sf=sf)
             comb_df_profiler.end_and_save_profiler()
             profile_manager.active_profilers.remove(comb_df_profiler)
@@ -268,7 +268,7 @@ def dat_to_dataframe(args):
 
     # Main program execution
 def main(cmd_args):
-    scan_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel2/"
+    scan_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel_debug/"
     dp_profiler = profile_manager.start_profiler("scan", 0, scan_time_dst, dataset = SCAN, restart=RESTART)
 
     """OKAY - Threading takes 0.0 seconds"""
@@ -383,7 +383,9 @@ def main(cmd_args):
 
     """ATTENTION - takes 3+ HOURS"""
     parallel_profiler.add_section("Execute parallelized function")
-    input_args = [(dat_file, datdir, fildir, outdir, obs, sf, count_lock, proc_count, ndats, before, after) for dat_file in dat_files]
+    # todo 
+    # input_args = [(dat_file, datdir, fildir, outdir, obs, sf, count_lock, proc_count, ndats, before, after) for dat_file in dat_files]
+    input_args = [(dat_file, datdir, fildir, outdir, obs, sf, count_lock, proc_count, ndats, before, after) for dat_file in dat_files[:2]]
     with Pool(num_processes) as pool:
         results = pool.map(dat_to_dataframe, input_args)
 

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -86,14 +86,16 @@ def check_cmd_args(args):
         datdir += "/"
     odict["datdir"] = datdir  
     if odict["fildir"]:
-        fildir = odict["fildir"][0]
+        # fildir = odict["fildir"][0]
+        fildir = odict["fildir"]
         if fildir[-1] != "/":
             fildir += "/"
         odict["fildir"] = fildir  
     else:
         odict["fildir"] = datdir
     if odict["outdir"]:
-        outdir = odict["outdir"][0]
+        # outdir = odict["outdir"][0]
+        outdir = odict["outdir"]
         if outdir[-1] != "/":
             outdir += "/"
         odict["outdir"] = outdir  
@@ -137,7 +139,9 @@ def dat_to_dataframe(args):
         # fils=sorted(glob.glob(fildir+subdirectories+fil_MJD+'*fil'))
         fils=sorted(glob.glob(fildir+subdirectories+os.path.basename(os.path.splitext(dat)[0])[:-4]+'????*fil'))
         if not fils:
+            print("No fil files. Looking for fbh5/h5 instead.")
             fils=sorted(glob.glob(fildir+subdirectories+os.path.basename(os.path.splitext(dat)[0])[:-4]+'????*h5'))
+        if not fils:
             logging.info(f'\tWARNING! Could not locate filterbank files in:\n\t{fildir+dat.split(datdir)[-1].split(dat.split("/")[-1])[0]}')
             logging.info(f'\tSkipping...\n')
             skipped+=1
@@ -178,6 +182,7 @@ def dat_to_dataframe(args):
             return pd.DataFrame(),hits,skipped,exact_matches
         else:
             logging.info(f"\tCombing through the remaining {len(df)} hits.")
+            print(np.shape(df))
             temp_df = DOT.comb_df(df,outdir,obs,pickle_off=True,sf=sf)
         mid, time_label = DOT.get_elapsed_time(start)
         logging.info(f"Finished processing in %.2f {time_label}." %mid)
@@ -233,7 +238,8 @@ def main(cmd_args):
                 break
     
     # file_handler = logging.FileHandler(log_filename) giving permission denied 
-    logfile = f"{os.getcwd()}/{logfile}"
+    # logfile = f"{os.getcwd()}/{logfile}"
+    logfile = logfile
     DOT.setup_logging(logfile)
     logger = logging.getLogger()
     logging.info("\nExecuting program...")
@@ -274,7 +280,9 @@ def main(cmd_args):
 
     # Concatenate the dataframes into a single dataframe
     full_df = pd.concat(result_dataframes, ignore_index=True)
-    full_df.to_csv(f"{outdir}{obs}_DOTnbeam.csv")
+    test_dst = os.path.join(os.getcwd(), f"{outdir}{obs}_DOTnbeam.csv")
+    full_df.to_csv(test_dst)
+    print(np.shape(full_df))
 
     # Do something with the counters if needed
     total_hits = sum(hits)

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -39,6 +39,7 @@ import psutil
 import threading
 from multiprocessing import Pool, Manager, Lock, Process
 from plot_utils import diagnostic_plotter
+sys.path.append('/mnt/primary/scratch/igerrard/ASP/blimpy')
 
     # Define Functions
 # monitor and print CPU usage during the parallel execution

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -79,11 +79,12 @@ def parse_args():
 def check_cmd_args(args):
     # Check for trailing slash in the directory path and add it if absent
     odict = args if type(args) == dict else vars(args)
-    if odict["datdir"]:
-        datdir = odict["datdir"][0]
-        if datdir[-1] != "/":
-            datdir += "/"
-        odict["datdir"] = datdir  
+    assert "datdir" in odict, print("No required data directory!")
+    # odict["datdir"] += "/"
+    datdir = odict["datdir"]
+    if datdir[-1] != "/":
+        datdir += "/"
+    odict["datdir"] = datdir  
     if odict["fildir"]:
         fildir = odict["fildir"][0]
         if fildir[-1] != "/":
@@ -137,7 +138,6 @@ def dat_to_dataframe(args):
         fils=sorted(glob.glob(fildir+subdirectories+os.path.basename(os.path.splitext(dat)[0])[:-4]+'????*fil'))
         if not fils:
             fils=sorted(glob.glob(fildir+subdirectories+os.path.basename(os.path.splitext(dat)[0])[:-4]+'????*h5'))
-        if not fils:
             logging.info(f'\tWARNING! Could not locate filterbank files in:\n\t{fildir+dat.split(datdir)[-1].split(dat.split("/")[-1])[0]}')
             logging.info(f'\tSkipping...\n')
             skipped+=1
@@ -360,4 +360,4 @@ def main(cmd_args):
 if __name__ == "__main__":
     # in this case the arguments are given as command line arguments
     cmd_args = parse_args()
-    main()
+    main(cmd_args)

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -121,7 +121,7 @@ def dat_to_dataframe(args):
     dat, datdir, fildir, outdir, obs, sf, count_lock, proc_count, ndats, before, after = args
     start = time.time()
 
-    dd_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel/data_to_dataframe/"+dat+"/"
+    dd_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel2/data_to_dataframe/"+dat+"/"
     dataframe_profiler = profile_manager.start_profiler("proc", "1_dat_to_dataframe", dd_time_dst, restart=RESTART)
 
     """ATTENTION - 0.0, 132m, 136m, 76m, 64m, 84m, 125m, 190m, 75m, 0.0, 3m, 69m, 38m
@@ -268,7 +268,7 @@ def dat_to_dataframe(args):
 
     # Main program execution
 def main(cmd_args):
-    scan_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel/"
+    scan_time_dst = f"/mnt/primary/scratch/igerrard/ASP/"+r"2024-12-13-02:09:48/"+"Finer/DOTParallel2/"
     dp_profiler = profile_manager.start_profiler("scan", 0, scan_time_dst, dataset = SCAN, restart=RESTART)
 
     """OKAY - Threading takes 0.0 seconds"""
@@ -281,7 +281,7 @@ def main(cmd_args):
     # Start a thread to monitor CPU usage during parallel execution
     monitor_thread = threading.Thread(target=monitor_cpu_usage, args=(samples,))
     monitor_thread.start()
-    """END - Threading takes 0.0 seconds""""
+    """END - Threading takes 0.0 seconds"""
 
     """OKAY - Args + File Management takes 0.0 seconds"""
     dp_profiler.add_section("Args + file management stuff")
@@ -507,6 +507,7 @@ def main(cmd_args):
 NIGHT = r"2024-12-13-02:09:48/"
 SCAN = r"fil_60657_39349_70813781_radec5.389,23.168_0001/"
 RESTART = False
+
 if __name__ == "__main__":
     # in this case the arguments are given as command line arguments
     # cmd_args = parse_args()

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -33,7 +33,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from matplotlib.ticker import ScalarFormatter
 # import DOT_utils as DOT
-import DOT_utils_copy as DOT
+import DOT_utils_edit as DOT
 import logging
 import psutil
 import threading

--- a/DOTparallel.py
+++ b/DOTparallel.py
@@ -72,8 +72,13 @@ def parse_args():
     parser.set_defaults(bliss=False)
     args = parser.parse_args()
 
+    args = check_cmd_args(args)
+    
+    return args
+
+def check_cmd_args(args):
     # Check for trailing slash in the directory path and add it if absent
-    odict = vars(args)
+    odict = args if type(args) == dict else vars(args)
     if odict["datdir"]:
         datdir = odict["datdir"][0]
         if datdir[-1] != "/":
@@ -93,6 +98,16 @@ def parse_args():
         odict["outdir"] = outdir  
     else:
         odict["outdir"] = ""
+
+    # Set defaults when not using parser bc not using cmd line args
+    if "beam" not in odict:
+        odict["beam"] = "0"
+    if "ncore" not in odict:
+        odict["ncore"] = None
+    if "after" not in odict:
+        odict["after"] = None
+    if "bliss" not in odict:
+        odict["bliss"] = False
     # Returns the input argument as a labeled array
     return odict
 
@@ -170,7 +185,7 @@ def dat_to_dataframe(args):
 
 
     # Main program execution
-def main():
+def main(cmd_args):
     start=time.time()
 
     global exit_flag
@@ -181,7 +196,7 @@ def main():
     monitor_thread.start()
 
     # parse the command line arguments
-    cmd_args = parse_args()
+    # cmd_args = parse_args()
     datdir = cmd_args["datdir"]     # required input
     fildir = cmd_args["fildir"]     # optional (but usually necessary)
     beam = cmd_args["beam"][0]      # optional, default = 0
@@ -216,6 +231,9 @@ def main():
             if completion_code in line:
                 os.remove(logfile)
                 break
+    
+    # file_handler = logging.FileHandler(log_filename) giving permission denied 
+    logfile = f"{os.getcwd()}/{logfile}"
     DOT.setup_logging(logfile)
     logger = logging.getLogger()
     logging.info("\nExecuting program...")
@@ -264,7 +282,7 @@ def main():
     total_exact_matches = sum(exact_matches)
 
     if sf==None:
-        sf=4
+        sf=4 
 
     if 'SNR_ratio' in full_df.columns and full_df['SNR_ratio'].notnull().any():
         # plot the histograms for hits within the target beam
@@ -340,4 +358,6 @@ def main():
     return None
 # run it!
 if __name__ == "__main__":
+    # in this case the arguments are given as command line arguments
+    cmd_args = parse_args()
     main()

--- a/plot_DOT_hits.py
+++ b/plot_DOT_hits.py
@@ -211,12 +211,12 @@ def limit_by_frange(df,fbelow,fabove):
 
 
     # Main program execution
-def main():
+def main(cmd_args):
     print("\nExecuting program...")
     start=time.time()
 
     # parse any command line arguments
-    cmd_args = parse_args()
+    # cmd_args = parse_args()
     csv = cmd_args["csv"][0]            # required input
     outdir = cmd_args["outdir"]         # optional, default to datdir listed in csv
     column = cmd_args["col"]            # optional, default None
@@ -368,4 +368,5 @@ def main():
     return None
 # run it!
 if __name__ == "__main__":
-    main()
+    cmd_args = parse_args()
+    main(cmd_args)


### PR DESCRIPTION
local version of blimpy and NBeamAnalysis for changes to io/hdf_reader.py and waterfall.py with potential time improvements based on fine grain profiling on NBeamAnalysis/DOTparallel.py and DOT_utils.py
- uses personal ASP/time_profile.py script for finer grain time profiling -> changes are based off of that profliing
- current version has lots of comments with what is taking what time 
- updated main functions to take in command arguments if want to call from command line / terminal or from another script 
- currently running with one core because doesn't seems like parallelizing was actually running in helpful way - is parallel but calls within different processes block others so they all end up running one at a time essentially (could be something with count_lock)
- main change was putting loading a node's waterfall metadata outside of the hit loop reduces overall time by about 30% 